### PR TITLE
Makefile Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MAN1=		man/port.1
 MAN5=		man/porttools.5
 
 # Normally provided via bsd.port.mk infrastructure
-PREFIX?=	~/pkg
+PREFIX?=	${HOME}/pkg
 DATADIR?=	${PREFIX}/share/${PORTNAME}
 DOCSDIR?=	${PREFIX}/share/doc/${PORTNAME}
 MANPREFIX?= ${PREFIX}
@@ -50,6 +50,7 @@ ${INC_HEADER}: ${INC_HEADER}.in
 	@chmod a+x ${.TARGET}
 
 install: ${IN_FILES}
+	mkdir -p ${DESTDIR}${PREFIX}/bin
 	${BSD_INSTALL_SCRIPT} ${PROGRAM} ${DESTDIR}${PREFIX}/bin
 	mkdir -p ${DESTDIR}${DATADIR}
 	${BSD_INSTALL_SCRIPT} ${SCRIPTS} ${DESTDIR}${DATADIR}


### PR DESCRIPTION
Change PREFIX to ${HOME}/pkg since ~ doesn't expand properly
Create bin directory before attempting to install binaries into it