### PR TITLE
Add support for creating new ports using a simple template system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MAN1=		man/port.1
 MAN5=		man/porttools.5
 
 # Normally provided via bsd.port.mk infrastructure
-PREFIX?=	~/pkg
+PREFIX?=	${HOME}/pkg
 DATADIR?=	${PREFIX}/share/${PORTNAME}
 DOCSDIR?=	${PREFIX}/share/doc/${PORTNAME}
 MANPREFIX?= ${PREFIX}
@@ -50,6 +50,7 @@ ${INC_HEADER}: ${INC_HEADER}.in
 	@chmod a+x ${.TARGET}
 
 install: ${IN_FILES}
+	mkdir -p ${DESTDIR}${PREFIX}/bin
 	${BSD_INSTALL_SCRIPT} ${PROGRAM} ${DESTDIR}${PREFIX}/bin
 	mkdir -p ${DESTDIR}${DATADIR}
 	${BSD_INSTALL_SCRIPT} ${SCRIPTS} ${DESTDIR}${DATADIR}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SCRIPTS=	scripts/cmd_commit scripts/cmd_create scripts/cmd_diff \
 IN_FILES=	${SCRIPTS} ${PROGRAM}
 INC_HEADER=	scripts/inc_header
 DOCS=		LICENSE NEWS README THANKS
+TEMPLATES=	tmpl
 MAN1=		man/port.1
 MAN5=		man/porttools.5
 
@@ -26,6 +27,7 @@ MAN5=		man/porttools.5
 PREFIX?=	${HOME}/pkg
 DATADIR?=	${PREFIX}/share/${PORTNAME}
 DOCSDIR?=	${PREFIX}/share/doc/${PORTNAME}
+TMPLDIR=	${PREFIX}/share/${PORTNAME}/tmpl
 MANPREFIX?= ${PREFIX}
 
 BSD_INSTALL_SCRIPT?=	install -m 555
@@ -58,6 +60,10 @@ install: ${IN_FILES}
 	${BSD_INSTALL_MAN} ${MAN1} ${DESTDIR}${MANPREFIX}/man/man1
 	mkdir -p ${DESTDIR}${MANPREFIX}/man/man5
 	${BSD_INSTALL_MAN} ${MAN5} ${DESTDIR}${MANPREFIX}/man/man5
+
+	mkdir -p ${TMPLDIR}
+	cd ${TEMPLATES} && find . | \
+		cpio -pdm ${TMPLDIR}
 
 install-docs:
 	mkdir -p ${DESTDIR}${DOCSDIR}

--- a/scripts/cmd_create.in
+++ b/scripts/cmd_create.in
@@ -112,7 +112,6 @@ case ${PORTPREFIX} in
 	py)
 		CATEGORIES=python
 		WWW=http://pypi.python.org/pypi/${PORTNAME}/
-		WANT_PKG_PLIST=Y
 		;;
 	*)
 		WWW=http://example.com

--- a/scripts/cmd_create.in
+++ b/scripts/cmd_create.in
@@ -11,12 +11,6 @@ if [ "${PORTTOOLS}" = "" ]; then
 	exit 1
 fi
 
-# Check to see if newfile(1) exists in PATH
-if [ "`which newfile`" = "" ]; then
-	echo "newfile(1) not found - please install devel/newfile port"
-	exit 1
-fi
-
 usage ()
 {
 cat << EOF
@@ -58,24 +52,85 @@ do
 	shift
 done
 
-PORTNAME=$2
+TEMPLATE_PREFIX=default
+ARG_PORTNAME=$2
 # Check if port name was supplied
-if [ "${PORTNAME}" = "" ]; then
+if [ "${ARG_PORTNAME}" = "" ]; then
 	echo "Error: port name not specified"
 	exit 1
 fi
 
 # Check if specified dir already exist
-if [ -e "${PORTNAME}" ]; then
-	echo "Error: ${PORTNAME} already exists"
+if [ -e "${ARG_PORTNAME}" ]; then
+	echo "Error: ${ARG_PORTNAME} already exists"
 	exit 1
+else
+	mkdir -p ${ARG_PORTNAME}
 fi
 
-# Run newfile(1)
-newfile --author="${FULLNAME}" --email="${EMAIL}" -pport."${PORTNAME}"
-if [ $? != 0 ]
+PORTBASE=$(basename ${ARG_PORTNAME})
+PORTPREFIX=$(echo ${PORTBASE} | cut -d- -f1)
+
+# Work around the fact that R modules are
+# prefixed with R-cran
+if [ "${PORTPREFIX}" = 'R' ]
 then
-	echo "Could not create port ${PORTNAME}"
-else
-	echo "===> Port ${PORTNAME} successfully created."
+	SECONDPORTPREFIX=$(echo ${PORTBASE} | cut -d- -f2)
+	if [ "${SECONDPORTPREFIX}" = 'cran' ]
+	then
+		PORTPREFIX="R-cran"
+	fi
 fi
+
+if [ ! -z ${PORTPREFIX} ]
+then
+	# Change the location of the port template files to
+	# use from default to the port prefix
+    TEMPLATE_PREFIX=${PORTPREFIX}
+
+	# Strip the port prefix from PORTNAME
+	PORTNAME=$(echo ${PORTBASE} | sed "s|${PORTPREFIX}-||")
+else
+	PORTNAME=${PORTBASE}
+fi
+
+case ${PORTPREFIX} in
+	p5)
+		CATEGORIES=perl5
+		MASTER_SITES=CPAN
+		PKGNAMEPREFIX=p5-
+		WWW=http://search.cpan.org/dist/${PORTNAME}/
+		WANT_PKG_PLIST=Y
+		;;
+	R-cran)
+		WWW=http://cran.r-project.org/web/${PORTNAME}/
+		;;
+	pear)
+		CATEGORIES=pear
+		WWW=http://pear.php.net/package/${PORTNAME}/
+		;;
+	py)
+		CATEGORIES=python
+		WWW=http://pypi.python.org/pypi/${PORTNAME}/
+		WANT_PKG_PLIST=Y
+		;;
+	*)
+		WWW=http://example.com
+		WANT_PKG_PLIST=Y
+		;;
+esac
+
+if [ ! -z ${WANT_PKG_PLIST} ]
+then
+	cp ${TEMPLATE_DIR}/common/pkg-plist.tmpl ${ARG_PORTNAME}/pkg-plist
+fi
+
+# Create pkg-descr
+sed "s|%%WWW%%|${WWW}|" < ${TEMPLATE_DIR}/common/pkg-descr.tmpl > ${ARG_PORTNAME}/pkg-descr
+
+# Create Makefile
+sed "s|%%PORTNAME%%|${PORTNAME}|g;
+	s|%%CATEGORIES%%|${CATEGORIES}|g;
+	s|%%MASTER_SITES%%|${MASTER_SITES}|g;
+	s|%%FULLNAME%%|${FULLNAME}|g;
+	s|%%EMAIL%%|${EMAIL}|g;" < ${TEMPLATE_DIR}/${TEMPLATE_PREFIX}/Makefile.tmpl > ${ARG_PORTNAME}/Makefile

--- a/scripts/port.in
+++ b/scripts/port.in
@@ -41,6 +41,7 @@ fi
 
 # Port Tools scripts location
 SCRIPT_DIR="__PREFIX__/share/porttools"
+TEMPLATE_DIR="${SCRIPT_DIR}/tmpl"
 
 # Run specified command
 CMD="$1"

--- a/tmpl/R-cran/Makefile.tmpl
+++ b/tmpl/R-cran/Makefile.tmpl
@@ -1,0 +1,14 @@
+# Created by: %%FULLNAME%% <%%EMAIL%%>
+# $FreeBSD$
+
+PORTNAME=	%%PORTNAME%%
+DISTVERSION=
+CATEGORIES=
+DISTNAME=	${PORTNAME}_${DISTVERSION}
+
+MAINTAINER=	%%EMAIL%%
+COMMENT=
+
+USES=	cran:auto-plist
+
+.include <bsd.port.mk>

--- a/tmpl/common/pkg-descr.tmpl
+++ b/tmpl/common/pkg-descr.tmpl
@@ -1,0 +1,3 @@
+[description of the port]
+
+WWW:	%%WWW%%

--- a/tmpl/common/pkg-plist.tmpl
+++ b/tmpl/common/pkg-plist.tmpl
@@ -1,0 +1,1 @@
+@comment $FreeBSD$

--- a/tmpl/default/Makefile.tmpl
+++ b/tmpl/default/Makefile.tmpl
@@ -1,0 +1,12 @@
+# Created by: %%FULLNAME%% <%%EMAIL%%>
+# $FreeBSD$
+
+PORTNAME=	%%PORTNAME%%
+PORTVERSION=
+CATEGORIES=
+MASTER_SITES=
+
+MAINTAINER=	%%EMAIL%%
+COMMENT=
+
+.include <bsd.port.mk>

--- a/tmpl/p5/Makefile.tmpl
+++ b/tmpl/p5/Makefile.tmpl
@@ -1,0 +1,15 @@
+# Created by: %%FULLNAME%% <%%EMAIL%%>
+# $FreeBSD$
+
+PORTNAME=	%%PORTNAME%%
+PORTVERSION=
+CATEGORIES= %%CATEGORIES%%
+MASTER_SITES=   CPAN
+PKGNAMEPREFIX=	p5-
+
+MAINTAINER=	%%EMAIL%%
+COMMENT=
+
+USES=	perl5
+
+.include <bsd.port.mk>

--- a/tmpl/pear/Makefile.tmpl
+++ b/tmpl/pear/Makefile.tmpl
@@ -1,0 +1,13 @@
+# Created by: %%FULLNAME%% <%%EMAIL%%>
+# $FreeBSD$
+
+PORTNAME=	%%PORTNAME%%
+PORTVERSION=
+CATEGORIES= %%CATEGORIES%%
+
+MAINTAINER=	%%EMAIL%%
+COMMENT=
+
+USES=	pear
+
+.include <bsd.port.mk>

--- a/tmpl/py/Makefile.tmpl
+++ b/tmpl/py/Makefile.tmpl
@@ -1,0 +1,16 @@
+# Created by: %%FULLNAME%% <%%EMAIL%%>
+# $FreeBSD$
+
+PORTNAME=	%%PORTNAME%%
+PORTVERSION=
+CATEGORIES= %%CATEGORIES%%
+MASTER_SITES=   CHEESESHOP
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	%%EMAIL%%
+COMMENT=
+
+USES=	python
+USE_PYTHON=	distutils autoplist
+
+.include <bsd.port.mk>


### PR DESCRIPTION
This change will remove the dependency on devel/newfile when creating a new port by using a simple template system that can expand various variables using sed

This also has the added benefit that you can now have port type specific templates that can autofill additional parts of the Makefile etc.
 
This add support for R-cran, p5, pear and py ports